### PR TITLE
feat: implement intervention interface and random event table

### DIFF
--- a/.vibe/state.yaml
+++ b/.vibe/state.yaml
@@ -1,3 +1,3 @@
 current_role: "Coding Agent (Claude Code / Codex)"
 current_issue: "5"
-current_step: "4_test_writing"
+current_step: "5_implementation"

--- a/src/pneuma_world/events.py
+++ b/src/pneuma_world/events.py
@@ -1,0 +1,80 @@
+"""EventQueue and RandomEventTable for the intervention interface."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from pathlib import Path
+
+import yaml
+
+from pneuma_world.models.event import WorldEvent
+
+
+class EventQueue:
+    """Async queue for world events.
+
+    Events are pushed from external sources (human, orchestrator, random table)
+    and drained at the start of each think tick.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[WorldEvent] = asyncio.Queue()
+
+    async def push(self, event: WorldEvent) -> None:
+        """Add an event to the queue."""
+        await self._queue.put(event)
+
+    def drain(self) -> list[WorldEvent]:
+        """Drain all pending events from the queue.
+
+        Called at the start of a think tick to collect all queued events.
+        Returns an empty list if the queue is empty.
+        """
+        events: list[WorldEvent] = []
+        while not self._queue.empty():
+            events.append(self._queue.get_nowait())
+        return events
+
+
+class RandomEventTable:
+    """Loads event definitions from YAML and selects events by weight.
+
+    YAML format:
+        events:
+          - type: environment
+            content: "窓の外で猫が鳴いている"
+            weight: 3
+          - type: physical
+            content: "棚から本が1冊落ちた"
+            weight: 1
+    """
+
+    def __init__(self, entries: list[dict]) -> None:
+        self.entries = entries
+
+    @classmethod
+    def from_yaml(cls, path: str) -> RandomEventTable:
+        """Load event definitions from a YAML file."""
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        entries = data.get("events", [])
+        return cls(entries=entries)
+
+    def roll(self) -> WorldEvent | None:
+        """Select a random event based on weights.
+
+        Returns None if the table has no entries.
+        """
+        if not self.entries:
+            return None
+
+        weights = [e["weight"] for e in self.entries]
+        chosen = random.choices(self.entries, weights=weights, k=1)[0]
+
+        return WorldEvent(
+            type=chosen["type"],
+            content=chosen["content"],
+            source="random_table",
+            target="world",
+        )

--- a/src/pneuma_world/models/event.py
+++ b/src/pneuma_world/models/event.py
@@ -1,0 +1,28 @@
+"""WorldEvent model for the intervention interface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import uuid
+
+
+@dataclass
+class WorldEvent:
+    """An event that can be injected into the world.
+
+    Attributes:
+        type: Event category - "environment" | "character_contact" | "scenario" | "physical"
+        content: Human-readable event description (e.g. "雨が降ってきた")
+        source: Origin of the event - "human" | "orchestrator" | "random_table"
+        target: Target scope - "world" (all characters) or a specific character_id
+        timestamp: When the event was created
+        id: Unique event identifier
+    """
+
+    type: str  # "environment" | "character_contact" | "scenario" | "physical"
+    content: str  # "雨が降ってきた" etc.
+    source: str  # "human" | "orchestrator" | "random_table"
+    target: str  # "world" | specific_character_id
+    timestamp: datetime = field(default_factory=datetime.now)
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))

--- a/src/pneuma_world/think_cycle.py
+++ b/src/pneuma_world/think_cycle.py
@@ -13,6 +13,8 @@ from pneuma_core.models.emotion import EmotionalState
 from pneuma_core.models.goals import GoalTree
 from pneuma_core.runtime.prompt_builder import PromptBuilder
 from pneuma_world.models.action import ActionType, MiniAction, ThinkResult
+from pneuma_world.models.action import ActionType, ThinkResult
+from pneuma_world.models.event import WorldEvent
 from pneuma_world.models.state import WorldState
 from pneuma_world.tools import ToolRegistry
 from pneuma_world.world_log import WorldLog
@@ -40,6 +42,7 @@ def _build_situation_context(
     character_name: str,
     world_state: WorldState,
     character_names: dict[str, str] | None = None,
+    pending_events: list[WorldEvent] | None = None,
 ) -> str:
     """Build a situation description from the world state."""
     char_state = world_state.characters.get(character_id)
@@ -73,6 +76,18 @@ def _build_situation_context(
 
     if char_state.conversation_id:
         lines.append(f"会話中: {char_state.conversation_id}")
+
+    # Inject pending events relevant to this character
+    if pending_events:
+        relevant = [
+            e for e in pending_events
+            if e.target == "world" or e.target == character_id
+        ]
+        if relevant:
+            lines.append("")
+            lines.append("## 発生中のイベント")
+            for event in relevant:
+                lines.append(f"- [{event.type}] {event.content}")
 
     return "\n".join(lines)
 

--- a/tests/world/test_events.py
+++ b/tests/world/test_events.py
@@ -231,7 +231,7 @@ class TestBuildSituationContextWithEvents:
             },
             active_conversations=[],
             locations={
-                "room1": Location(id="room1", name="部屋1", walkable_polygon=[]),
+                "room1": Location(id="room1", name="部屋1", bounds=(Position(0, 0), Position(100, 100))),
             },
         )
 
@@ -267,7 +267,7 @@ class TestBuildSituationContextWithEvents:
             },
             active_conversations=[],
             locations={
-                "room1": Location(id="room1", name="部屋1", walkable_polygon=[]),
+                "room1": Location(id="room1", name="部屋1", bounds=(Position(0, 0), Position(100, 100))),
             },
         )
 
@@ -316,7 +316,7 @@ class TestBuildSituationContextWithEvents:
             },
             active_conversations=[],
             locations={
-                "room1": Location(id="room1", name="部屋1", walkable_polygon=[]),
+                "room1": Location(id="room1", name="部屋1", bounds=(Position(0, 0), Position(100, 100))),
             },
         )
 


### PR DESCRIPTION
Closes #5

## Summary
- `WorldEvent` dataclass（models/event.py）
- `EventQueue`（asyncio.Queue ベース、push/drain）
- `RandomEventTable`（YAML 読み込み、weight ベース選択）
- `_build_situation_context()` に pending_events 注入（target フィルタリング対応）

## Test Plan
- [x] 229 tests passed (既存207 + 新規22)