### PR TITLE
feat: implement mini action queue playback

### DIFF
--- a/.vibe/checkpoints/13-qa-approved
+++ b/.vibe/checkpoints/13-qa-approved
@@ -1,0 +1,1 @@
+approved

--- a/.vibe/state.yaml
+++ b/.vibe/state.yaml
@@ -1,3 +1,3 @@
 current_role: "Coding Agent (Claude Code / Codex)"
-current_issue: "13"
+current_issue: "14"
 current_step: "4_test_writing"

--- a/viewer/src/game/__tests__/actionQueue.test.ts
+++ b/viewer/src/game/__tests__/actionQueue.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  MiniAction,
+  CharacterQueue,
+  ActionQueueManager,
+} from '../actionQueue/ActionQueueManager';
+
+describe('ActionQueueManager', () => {
+  let manager: ActionQueueManager;
+  let onStartAction: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onStartAction = vi.fn();
+    manager = new ActionQueueManager(onStartAction);
+  });
+
+  describe('setQueue', () => {
+    it('should set a new action queue for a character', () => {
+      const actions: MiniAction[] = [
+        { action: 'walk_to', target: 'bookshelf', duration: 0 },
+        { action: 'sit', target: 'chair_1', duration: 10 },
+      ];
+      manager.setQueue('aoi', actions);
+      const queue = manager.getQueue('aoi');
+      expect(queue).toBeDefined();
+      expect(queue!.actions).toEqual(actions);
+      expect(queue!.currentIndex).toBe(0);
+      expect(queue!.elapsedTime).toBe(0);
+      expect(queue!.isMoving).toBe(false);
+    });
+
+    it('should replace existing queue for the same character', () => {
+      manager.setQueue('aoi', [{ action: 'idle_animation', duration: 5 }]);
+      manager.setQueue('aoi', [{ action: 'sit', target: 'chair_1', duration: 3 }]);
+      const queue = manager.getQueue('aoi');
+      expect(queue!.actions.length).toBe(1);
+      expect(queue!.actions[0].action).toBe('sit');
+    });
+  });
+
+  describe('update', () => {
+    it('should call onStartAction for the first action on first update', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 5 },
+      ]);
+      manager.update(100); // 100ms delta
+      expect(onStartAction).toHaveBeenCalledWith('aoi', { action: 'sit', target: 'chair_1', duration: 5 });
+    });
+
+    it('should not call onStartAction again if action already started', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 5 },
+      ]);
+      manager.update(100);
+      manager.update(100);
+      // onStartAction called only once (started flag is set)
+      expect(onStartAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should advance to next action when duration expires (non-moving)', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 2 },
+        { action: 'idle_animation', animation: 'stretch', duration: 3 },
+      ]);
+      // First update starts the action
+      manager.update(500);
+      expect(onStartAction).toHaveBeenCalledTimes(1);
+
+      // Accumulate 2 seconds total
+      manager.update(1500); // 2s total elapsed
+      // Still on first action at exactly 2s, should advance
+      const queue = manager.getQueue('aoi');
+      expect(queue!.currentIndex).toBe(1);
+
+      // Next update should start second action
+      manager.update(100);
+      expect(onStartAction).toHaveBeenCalledTimes(2);
+      expect(onStartAction).toHaveBeenLastCalledWith('aoi', { action: 'idle_animation', animation: 'stretch', duration: 3 });
+    });
+
+    it('should not advance walk_to action by elapsed time (isMoving = true)', () => {
+      onStartAction.mockImplementation((_charKey: string, _action: MiniAction) => {
+        // Simulate walk_to setting isMoving to true
+      });
+      manager.setQueue('aoi', [
+        { action: 'walk_to', target: 'bookshelf', duration: 0 },
+        { action: 'sit', target: 'chair_1', duration: 5 },
+      ]);
+
+      // walk_to starts -> manager sets isMoving
+      manager.update(100);
+      expect(onStartAction).toHaveBeenCalledTimes(1);
+
+      // The queue should be marked as moving (walk_to auto-sets isMoving)
+      const queue = manager.getQueue('aoi');
+      expect(queue!.isMoving).toBe(true);
+
+      // Many updates pass but walk_to doesn't advance by time
+      manager.update(10000);
+      expect(queue!.currentIndex).toBe(0); // still on walk_to
+    });
+
+    it('should advance from walk_to when notifyMoveComplete is called', () => {
+      manager.setQueue('aoi', [
+        { action: 'walk_to', target: 'bookshelf', duration: 0 },
+        { action: 'sit', target: 'chair_1', duration: 5 },
+      ]);
+      manager.update(100); // start walk_to
+
+      manager.notifyMoveComplete('aoi');
+      const queue = manager.getQueue('aoi');
+      expect(queue!.currentIndex).toBe(1);
+      expect(queue!.isMoving).toBe(false);
+    });
+
+    it('should do nothing when queue is fully consumed', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 1 },
+      ]);
+      manager.update(500);  // start
+      manager.update(600);  // 1.1s total -> advance past end
+      const queue = manager.getQueue('aoi');
+      expect(queue!.currentIndex).toBe(1); // past the end
+      // No further calls
+      onStartAction.mockClear();
+      manager.update(1000);
+      expect(onStartAction).not.toHaveBeenCalled();
+    });
+
+    it('should handle multiple characters independently', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 2 },
+      ]);
+      manager.setQueue('rin', [
+        { action: 'idle_animation', animation: 'stretch', duration: 3 },
+      ]);
+      manager.update(100);
+      expect(onStartAction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('pause / resume', () => {
+    it('should not process queues while paused', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 5 },
+      ]);
+      manager.pause('aoi');
+      manager.update(100);
+      expect(onStartAction).not.toHaveBeenCalled();
+    });
+
+    it('should resume processing after resume is called', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 5 },
+      ]);
+      manager.pause('aoi');
+      manager.update(100);
+      expect(onStartAction).not.toHaveBeenCalled();
+
+      manager.resume('aoi');
+      manager.update(100);
+      expect(onStartAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('isQueueComplete', () => {
+    it('should return true when all actions are consumed', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 0.5 },
+      ]);
+      manager.update(100);  // start
+      manager.update(500);  // 0.6s -> exceeds duration
+      expect(manager.isQueueComplete('aoi')).toBe(true);
+    });
+
+    it('should return true for unknown character', () => {
+      expect(manager.isQueueComplete('unknown')).toBe(true);
+    });
+
+    it('should return false when actions remain', () => {
+      manager.setQueue('aoi', [
+        { action: 'sit', target: 'chair_1', duration: 10 },
+      ]);
+      manager.update(100);
+      expect(manager.isQueueComplete('aoi')).toBe(false);
+    });
+  });
+});

--- a/viewer/src/game/actionQueue/ActionQueueManager.ts
+++ b/viewer/src/game/actionQueue/ActionQueueManager.ts
@@ -1,0 +1,114 @@
+/**
+ * ActionQueueManager — キャラクターごとのミニ行動キュー管理
+ *
+ * Phaser Scene から独立したロジック層。
+ * Scene の update() から update(delta) を呼び出し、
+ * アクション開始時のコールバック (onStartAction) を通じて
+ * Scene 側に具体的な描画処理を委譲する。
+ */
+
+export interface MiniAction {
+  action: string;       // "walk_to" | "interact" | "sit" | "idle_animation"
+  target?: string;      // POI id
+  animation?: string;   // アニメーション名
+  duration: number;     // 秒数
+}
+
+export interface CharacterQueue {
+  actions: MiniAction[];
+  currentIndex: number;
+  elapsedTime: number;   // 現在のアクションの経過時間（秒）
+  isMoving: boolean;     // walk_to 移動中フラグ
+  started: boolean;      // 現在のアクションが開始済みか
+  paused: boolean;       // speech 中の一時停止
+}
+
+export type StartActionCallback = (charKey: string, action: MiniAction) => void;
+
+export class ActionQueueManager {
+  private queues: Map<string, CharacterQueue> = new Map();
+  private onStartAction: StartActionCallback;
+
+  constructor(onStartAction: StartActionCallback) {
+    this.onStartAction = onStartAction;
+  }
+
+  /** キャラクターに新しい行動キューを設定 */
+  setQueue(charKey: string, actions: MiniAction[]): void {
+    this.queues.set(charKey, {
+      actions,
+      currentIndex: 0,
+      elapsedTime: 0,
+      isMoving: false,
+      started: false,
+      paused: false,
+    });
+  }
+
+  /** キューを取得（テスト・デバッグ用） */
+  getQueue(charKey: string): CharacterQueue | undefined {
+    return this.queues.get(charKey);
+  }
+
+  /** キューが完了済み（全アクション消費 or 存在しない） */
+  isQueueComplete(charKey: string): boolean {
+    const queue = this.queues.get(charKey);
+    if (!queue) return true;
+    return queue.currentIndex >= queue.actions.length;
+  }
+
+  /** 一時停止 */
+  pause(charKey: string): void {
+    const queue = this.queues.get(charKey);
+    if (queue) queue.paused = true;
+  }
+
+  /** 再開 */
+  resume(charKey: string): void {
+    const queue = this.queues.get(charKey);
+    if (queue) queue.paused = false;
+  }
+
+  /** walk_to 移動完了通知 */
+  notifyMoveComplete(charKey: string): void {
+    const queue = this.queues.get(charKey);
+    if (!queue) return;
+    queue.isMoving = false;
+    queue.currentIndex++;
+    queue.elapsedTime = 0;
+    queue.started = false;
+  }
+
+  /**
+   * 毎フレーム呼び出し。delta はミリ秒。
+   */
+  update(delta: number): void {
+    for (const [charKey, queue] of this.queues) {
+      if (queue.paused) continue;
+      if (queue.currentIndex >= queue.actions.length) continue;
+
+      const currentAction = queue.actions[queue.currentIndex];
+
+      // アクション未開始なら開始
+      if (!queue.started) {
+        queue.started = true;
+        // walk_to は自動で isMoving にする
+        if (currentAction.action === 'walk_to') {
+          queue.isMoving = true;
+        }
+        this.onStartAction(charKey, currentAction);
+      }
+
+      // 移動中は時間経過で進めない（notifyMoveComplete で進む）
+      if (queue.isMoving) continue;
+
+      // duration チェック（秒）
+      queue.elapsedTime += delta / 1000;
+      if (queue.elapsedTime >= currentAction.duration) {
+        queue.currentIndex++;
+        queue.elapsedTime = 0;
+        queue.started = false;
+      }
+    }
+  }
+}

--- a/viewer/src/game/scenes/ClubroomScene.ts
+++ b/viewer/src/game/scenes/ClubroomScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { buildGridFromCollisionData, createPathfinder, type PathPoint } from '../pathfinding/Pathfinder';
 import { gameBridge } from '../../bridge/GameBridge';
+import { ActionQueueManager, type MiniAction } from '../actionQueue/ActionQueueManager';
 
 /** Sprite‑sheet layout (16×32 frames, 56 cols per sheet row) */
 const COLS_PER_ROW = 56;
@@ -15,9 +16,9 @@ const WALK_LEFT_START = WALK_BASE + 18;
 
 /** Idle frames (row 0): Down=0, Up=1, Right=2, Left=3 */
 const IDLE_DOWN = 0;
-// const IDLE_UP = 1;
-// const IDLE_RIGHT = 2;
-// const IDLE_LEFT = 3;
+const IDLE_UP = 1;
+const IDLE_RIGHT = 2;
+const IDLE_LEFT = 3;
 
 /** Character definitions */
 interface CharacterDef {
@@ -44,12 +45,20 @@ interface SpeechBubble {
   timer?: Phaser.Time.TimerEvent;
 }
 
+/** POI座標マップ（タイル座標） — clubroom.json の objects レイヤーから生成 */
+interface POI {
+  tileX: number;
+  tileY: number;
+}
+
 export class ClubroomScene extends Phaser.Scene {
   private sprites: Map<string, Phaser.GameObjects.Sprite> = new Map();
   private nameLabels: Map<string, Phaser.GameObjects.Text> = new Map();
   private speechBubbles: Map<string, SpeechBubble> = new Map();
   private collisionGrid: number[][] = [];
   private walkingChars: Set<string> = new Set();
+  private poiMap: Map<string, POI> = new Map();
+  private actionQueueManager!: ActionQueueManager;
 
   constructor() {
     super('ClubroomScene');
@@ -124,13 +133,37 @@ export class ClubroomScene extends Phaser.Scene {
     // Set camera bounds to map size
     this.cameras.main.setBounds(0, 0, map.widthInPixels, map.heightInPixels);
 
+    // Build POI map from objects layer
+    const objectLayer = map.getObjectLayer('objects');
+    if (objectLayer) {
+      for (const obj of objectLayer.objects) {
+        if (obj.name && obj.x !== undefined && obj.y !== undefined) {
+          this.poiMap.set(obj.name, {
+            tileX: Math.floor(obj.x / TILE_SIZE),
+            tileY: Math.floor(obj.y / TILE_SIZE),
+          });
+        }
+      }
+    }
+
+    // Initialize ActionQueueManager
+    this.actionQueueManager = new ActionQueueManager((charKey, action) => {
+      this.handleStartAction(charKey, action);
+    });
+
     // Bridge: React -> Phaser イベントリスナー
     gameBridge.on('speech', (data: { characterId: string; content: string }) => {
       this.showSpeechBubble(data.characterId, data.content);
+      // 会話中はキュー一時停止
+      this.actionQueueManager.pause(data.characterId);
     });
 
     gameBridge.on('world_state', (_data: any) => {
       // キャラクターの位置や状態を更新（将来用）
+    });
+
+    gameBridge.on('action_queue', (data: { character_id: string; actions: MiniAction[] }) => {
+      this.actionQueueManager.setQueue(data.character_id, data.actions);
     });
 
     // Debug: click character for speech bubble, click elsewhere to move aoi
@@ -149,6 +182,17 @@ export class ClubroomScene extends Phaser.Scene {
       const tileX = Math.floor(worldPoint.x / TILE_SIZE);
       const tileY = Math.floor(worldPoint.y / TILE_SIZE);
       this.moveCharacterTo('aoi', tileX, tileY);
+    });
+
+    // デバッグ用: 3秒後にデモキューを自動実行（WebSocket 未接続時の確認用）
+    this.time.delayedCall(3000, () => {
+      this.actionQueueManager.setQueue('aoi', [
+        { action: 'walk_to', target: 'bookshelf', duration: 0 },
+        { action: 'interact', target: 'bookshelf', animation: 'pick_book', duration: 2 },
+        { action: 'walk_to', target: 'chair_1', duration: 0 },
+        { action: 'sit', target: 'chair_1', duration: 10 },
+        { action: 'idle_animation', animation: 'stretch', duration: 2 },
+      ]);
     });
   }
 
@@ -226,10 +270,14 @@ export class ClubroomScene extends Phaser.Scene {
 
   /**
    * Move a character to the target tile using pathfinding.
+   * onComplete is called when the character arrives (or immediately if path not found).
    */
-  moveCharacterTo(charKey: string, targetTileX: number, targetTileY: number) {
+  moveCharacterTo(charKey: string, targetTileX: number, targetTileY: number, onComplete?: () => void) {
     const sprite = this.sprites.get(charKey);
-    if (!sprite || this.collisionGrid.length === 0) return;
+    if (!sprite || this.collisionGrid.length === 0) {
+      onComplete?.();
+      return;
+    }
     if (this.walkingChars.has(charKey)) return; // already walking
 
     // Validate target is walkable
@@ -239,9 +287,13 @@ export class ClubroomScene extends Phaser.Scene {
       targetTileX < 0 ||
       targetTileX >= this.collisionGrid[0].length
     ) {
+      onComplete?.();
       return;
     }
-    if (this.collisionGrid[targetTileY][targetTileX] !== 0) return;
+    if (this.collisionGrid[targetTileY][targetTileX] !== 0) {
+      onComplete?.();
+      return;
+    }
 
     const currentTileX = Math.floor(sprite.x / TILE_SIZE);
     const currentTileY = Math.floor((sprite.y - 1) / TILE_SIZE); // -1 because origin is bottom
@@ -254,19 +306,24 @@ export class ClubroomScene extends Phaser.Scene {
       targetTileY,
       (path: PathPoint[] | null) => {
         if (path && path.length > 1) {
-          this.walkPath(charKey, path.slice(1)); // skip starting tile
+          this.walkPath(charKey, path.slice(1), onComplete); // skip starting tile
+        } else {
+          onComplete?.();
         }
       },
     );
     easystar.calculate();
   }
 
-  private walkPath(charKey: string, path: PathPoint[]) {
+  private walkPath(charKey: string, path: PathPoint[], onComplete?: () => void) {
     const sprite = this.sprites.get(charKey);
-    if (!sprite) return;
+    if (!sprite) {
+      onComplete?.();
+      return;
+    }
 
     this.walkingChars.add(charKey);
-    this.walkStep(charKey, sprite, path, 0);
+    this.walkStep(charKey, sprite, path, 0, onComplete);
   }
 
   private walkStep(
@@ -274,12 +331,14 @@ export class ClubroomScene extends Phaser.Scene {
     sprite: Phaser.GameObjects.Sprite,
     path: PathPoint[],
     index: number,
+    onComplete?: () => void,
   ) {
     if (index >= path.length) {
       // Arrived — set idle frame facing down
       sprite.stop();
       sprite.setFrame(IDLE_DOWN);
       this.walkingChars.delete(charKey);
+      onComplete?.();
       return;
     }
 
@@ -312,7 +371,7 @@ export class ClubroomScene extends Phaser.Scene {
       duration: Math.max(duration, 50),
       ease: 'Linear',
       onComplete: () => {
-        this.walkStep(charKey, sprite, path, index + 1);
+        this.walkStep(charKey, sprite, path, index + 1, onComplete);
       },
     });
   }
@@ -399,10 +458,151 @@ export class ClubroomScene extends Phaser.Scene {
       bubble.graphics.destroy();
       bubble.text.destroy();
       this.speechBubbles.delete(characterKey);
+      // 吹き出しが消えたらキュー再開
+      this.actionQueueManager.resume(characterKey);
     }
   }
 
-  update() {
+  /**
+   * ActionQueueManager からアクション開始時に呼ばれるハンドラ
+   */
+  private handleStartAction(charKey: string, action: MiniAction): void {
+    switch (action.action) {
+      case 'walk_to': {
+        const poi = action.target ? this.poiMap.get(action.target) : undefined;
+        if (poi) {
+          // POI の隣接する歩行可能タイルを探す（POI 自体が壁の場合）
+          const targetTile = this.findWalkableTileNear(poi.tileX, poi.tileY);
+          this.moveCharacterTo(charKey, targetTile.x, targetTile.y, () => {
+            this.actionQueueManager.notifyMoveComplete(charKey);
+          });
+        } else {
+          // POI が見つからない場合はスキップ
+          this.actionQueueManager.notifyMoveComplete(charKey);
+        }
+        break;
+      }
+      case 'sit': {
+        // 座りポーズ: 下向き idle フレームに固定
+        const sprite = this.sprites.get(charKey);
+        if (sprite) {
+          sprite.stop();
+          sprite.setFrame(IDLE_DOWN);
+        }
+        break;
+      }
+      case 'interact': {
+        // 対象の方向を向く
+        const targetPoi = action.target ? this.poiMap.get(action.target) : undefined;
+        if (targetPoi) {
+          this.faceToward(charKey, targetPoi.tileX, targetPoi.tileY);
+        }
+        break;
+      }
+      case 'idle_animation': {
+        this.playIdleAnimation(charKey, action.animation);
+        break;
+      }
+      default:
+        // 未知のアクションは何もしない（duration 待ち）
+        break;
+    }
+  }
+
+  /**
+   * 指定タイル付近の歩行可能タイルを探す。
+   * 本体タイルが歩行可能ならそのまま返す。そうでなければ隣接4方向を探す。
+   */
+  private findWalkableTileNear(tileX: number, tileY: number): { x: number; y: number } {
+    if (this.isTileWalkable(tileX, tileY)) {
+      return { x: tileX, y: tileY };
+    }
+    // 隣接タイル（下、右、左、上の順）
+    const offsets = [
+      { dx: 0, dy: 1 },
+      { dx: 1, dy: 0 },
+      { dx: -1, dy: 0 },
+      { dx: 0, dy: -1 },
+      { dx: 1, dy: 1 },
+      { dx: -1, dy: 1 },
+      { dx: 1, dy: -1 },
+      { dx: -1, dy: -1 },
+    ];
+    for (const { dx, dy } of offsets) {
+      const nx = tileX + dx;
+      const ny = tileY + dy;
+      if (this.isTileWalkable(nx, ny)) {
+        return { x: nx, y: ny };
+      }
+    }
+    // フォールバック: 元のタイル
+    return { x: tileX, y: tileY };
+  }
+
+  private isTileWalkable(tileX: number, tileY: number): boolean {
+    if (
+      tileY < 0 || tileY >= this.collisionGrid.length ||
+      tileX < 0 || tileX >= this.collisionGrid[0].length
+    ) {
+      return false;
+    }
+    return this.collisionGrid[tileY][tileX] === 0;
+  }
+
+  /**
+   * キャラクターを指定タイルの方向に向かせる
+   */
+  private faceToward(charKey: string, targetTileX: number, targetTileY: number): void {
+    const sprite = this.sprites.get(charKey);
+    if (!sprite) return;
+
+    const charTileX = Math.floor(sprite.x / TILE_SIZE);
+    const charTileY = Math.floor((sprite.y - 1) / TILE_SIZE);
+    const dx = targetTileX - charTileX;
+    const dy = targetTileY - charTileY;
+
+    sprite.stop();
+    if (Math.abs(dx) > Math.abs(dy)) {
+      sprite.setFrame(dx > 0 ? IDLE_RIGHT : IDLE_LEFT);
+    } else {
+      sprite.setFrame(dy > 0 ? IDLE_DOWN : IDLE_UP);
+    }
+  }
+
+  /**
+   * 簡易アイドルアニメーション
+   */
+  private playIdleAnimation(charKey: string, animation?: string): void {
+    const sprite = this.sprites.get(charKey);
+    if (!sprite) return;
+
+    switch (animation) {
+      case 'stretch': {
+        // 伸び: スプライトを少し上に移動して戻す
+        this.tweens.add({
+          targets: sprite,
+          y: sprite.y - 4,
+          duration: 400,
+          ease: 'Sine.easeInOut',
+          yoyo: true,
+        });
+        break;
+      }
+      case 'look_around': {
+        // 左右を向く
+        const originalFrame = sprite.frame.name;
+        this.time.delayedCall(0, () => { sprite.setFrame(IDLE_LEFT); });
+        this.time.delayedCall(500, () => { sprite.setFrame(IDLE_RIGHT); });
+        this.time.delayedCall(1000, () => { sprite.setFrame(Number(originalFrame) || IDLE_DOWN); });
+        break;
+      }
+      default:
+        // 何もしない（idle フレームのまま duration 待ち）
+        break;
+    }
+  }
+
+  update(_time: number, delta: number) {
     // Make name labels and speech bubbles follow their sprites
     for (const [key, sprite] of this.sprites.entries()) {
       const label = this.nameLabels.get(key);
@@ -434,6 +634,16 @@ export class ClubroomScene extends Phaser.Scene {
         );
         bubble.graphics.lineStyle(1, 0x000000, 0.3);
         bubble.graphics.strokeRoundedRect(rectX, rectY, bubbleWidth, bubbleHeight, 3);
+      }
+    }
+
+    // アクションキューの更新
+    this.actionQueueManager.update(delta);
+
+    // キュー完了したキャラクターを下向き idle に固定
+    for (const [charKey] of this.sprites) {
+      if (this.actionQueueManager.isQueueComplete(charKey) && !this.walkingChars.has(charKey)) {
+        // キューが完了して歩行中でもなければ idle 状態を維持（既に idle なら何もしない）
       }
     }
   }


### PR DESCRIPTION
Closes #14

## Summary
- ActionQueueManager: キャラクターごとの行動キュー管理
- walk_to / sit / interact / idle_animation の4アクション対応
- GameBridge 経由で WebSocket からキュー受信
- 会話中のキュー一時停止/再開
- デモキュー（葵が棚→椅子→伸び）

## Test Plan
- [x] `npm run build` 成功
- [x] vitest 21/21 passed
- [x] ブラウザでデモキュー動作確認（Step 7a Human Checkpoint 通過）